### PR TITLE
1 플레이어가 북쪽 서쪽 바라볼때 거리가 반대로 반영되는 문제

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #    By: jiyunpar <jiyunpar@student.42seoul.kr>     +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2022/10/17 09:21:03 by jiyunpar          #+#    #+#              #
-#    Updated: 2023/01/30 17:38:49 by jiyunpar         ###   ########.fr        #
+#    Updated: 2023/01/31 13:51:54 by jiyunpar         ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -42,7 +42,7 @@ LIB					= 	-lft -lmlx
 
 INCLUDE				=	-I./include -I$(MLX_DIR) -I$(LIBFT_DIR)
 
-CFLAGS				=	-Wall -Wextra -Werror
+CFLAGS				=	-Wall -Wextra -Werror -g3
 
 %.o : %.c
 	$(CC) $(CFLAGS) $(INCLUDE) -c $< -o $@

--- a/include/cub3d.h
+++ b/include/cub3d.h
@@ -81,8 +81,6 @@ typedef struct s_player
 	double	dir_y;
 	double	plane_x;
 	double	plane_y;
-	double	raydir_x;
-	double	raydir_y;
 }	t_player;
 
 typedef struct s_raycast

--- a/src/launch_game/render_wall.c
+++ b/src/launch_game/render_wall.c
@@ -6,7 +6,7 @@
 /*   By: jiyunpar <jiyunpar@student.42seoul.kr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/01/27 20:59:53 by jiyunpar          #+#    #+#             */
-/*   Updated: 2023/01/30 17:33:08 by jiyunpar         ###   ########.fr       */
+/*   Updated: 2023/01/31 14:54:12 by jiyunpar         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,7 +14,7 @@
 
 static void	caculate_init_dist(t_data *data, t_raycast *cur_state)
 {
-	if (data->player->raydir_x < 0)
+	if (cur_state->raydir_x < 0)
 	{
 		cur_state->step_x = -1;
 		cur_state->sidedist_x = (data->player->pos_x - cur_state->map_x)
@@ -26,7 +26,7 @@ static void	caculate_init_dist(t_data *data, t_raycast *cur_state)
 		cur_state->sidedist_x = (cur_state->map_x + 1.0 - data->player->pos_x)
 			* cur_state->deltadist_x;
 	}
-	if (data->player->raydir_y < 0)
+	if (cur_state->raydir_y < 0)
 	{
 		cur_state->step_y = -1;
 		cur_state->sidedist_y = (data->player->pos_y - cur_state->map_y)


### PR DESCRIPTION
t_raycast 안에 있는 raydir_x, raydir_y를 사용해야 하는데
t_player안에 있는 raydir_x, raydir_y를 사용해서 초기화되지 않은 값으로 계산이 되고 있었습니다.
필요없는 member 변수는 삭제하였습니다.